### PR TITLE
logger: remove loggerInit() function

### DIFF
--- a/example/main.c
+++ b/example/main.c
@@ -9,7 +9,6 @@
 int main(void)
 {
 	i32 error;
-	loggerInit();
 	loggerSetLevel(LOGGER_DEBUG);
 
 	Window window;

--- a/include/pogona/logger.h
+++ b/include/pogona/logger.h
@@ -19,7 +19,6 @@ typedef enum {
 
 #define LOGGER_DEFAULT_LEVEL LOGGER_INFO
 
-void loggerInit();
 void loggerSetLevel(LoggerLevel level);
 void loggerLog(LoggerLevel level, const char* sourceFile, usize sourceLine, const char* fmt, ...);
 

--- a/src/logger.c
+++ b/src/logger.c
@@ -21,18 +21,13 @@ static const char* sLevelStrings[] = { "TRACE", "DEBUG", "INFO", "WARNING", "ERR
 
 static const char* sLevelColours[] = { "\x1b[94m", "\x1b[36m", "\x1b[32m", "\x1b[33m", "\x1b[31m", "\x1b[35m" };
 
-void loggerInit()
-{
-	{
-		time_t rawTime = time(NULL);
-		sLogger.time = localtime(&rawTime);
-	}
-}
-
 void loggerLog(LoggerLevel level, const char* sourceFile, usize sourceLine, const char* fmt, ...)
 {
 	if (level < sLogger.level)
 		return;
+
+	time_t rawTime = time(NULL);
+	sLogger.time = localtime(&rawTime);
 
 	va_list ap;
 	va_start(ap, fmt);


### PR DESCRIPTION
This fixes issue #1. It was setting the time only once, in the init() function, which is incorrect.